### PR TITLE
✅ 🐛 | fix blur bug & add logo

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -43,7 +43,7 @@
     <!-- nav responsive ouverte -->
     <nav
       :class="{ hidden: isActive }"
-      class="lg:hidden w-full absolute top-0 h-screen z-40 grid grid-cols-2 grid-rows-4 bg-opacity-40 backdrop-blur-sm bg-black"
+      class="lg:hidden w-full absolute top-0 h-screen z-40 grid grid-cols-2 grid-rows-4 bg-opacity-40 backgroundBlur bg-black"
     >
       <div
         class="grid grid-cols-2 grid-rows-1 col-span-2 my-4 h-12 justify-items-center w-full "

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="relative overflow-hidden">
-      <video autoplay loop muted playsinline class="blur-1 w-full">
+      <video autoplay loop muted playsinline class="blur-element w-full">
         <source src="/oceanVideo.mp4" type="video/mp4" />
         Your browser does not support the video tag.
       </video>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -30,7 +30,12 @@ html {
   opacity: 0;
   transition: opacity 0.5s ease-in-out;
 }
-
+.backgroundBlur{
+  backdrop-filter: blur(4px);
+}
+.blur-element{
+  filter: blur(1px);
+}
 .fade-scroll.visible {
   opacity: 1;
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -12,7 +12,7 @@ export default {
       { name: 'format-detection', content: 'telephone=no' }
     ],
     link: [
-      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+      { rel: 'icon', type: 'image/x-icon', href: '/Logo.png' },
       {
         rel: "stylesheet",
         href: "https://fonts.googleapis.com/css2?family=Lexend:wght@300&family=Rubik+Doodle+Shadow&display=swap"


### PR DESCRIPTION
Add backdrop blur effect on the mobile navigation, and adjust the video blur effect. Also, update the favicon link to use the new logo. Addresses the bug related to the blur effect and enhances the visual appeal. 🐛